### PR TITLE
Add vertex class and integrate with graphics view

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1,14 +1,78 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
+#include "vertex.h"
+
+#include <QGraphicsScene>
+#include <QGraphicsView>
+#include <QPainter>
+
+#include <algorithm>
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
     , ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
+
+    m_scene = new QGraphicsScene(this);
+    m_scene->setSceneRect(0, 0, 800, 600);
+    ui->graphicsView->setScene(m_scene);
+    ui->graphicsView->setRenderHint(QPainter::Antialiasing);
 }
 
 MainWindow::~MainWindow()
 {
+    m_vertices.clear();
     delete ui;
+}
+
+Vertex *MainWindow::createVertex(const QPointF &position)
+{
+    auto vertex = std::make_unique<Vertex>(position, m_scene);
+    Vertex *vertexPtr = vertex.get();
+    m_vertices.push_back(std::move(vertex));
+    return vertexPtr;
+}
+
+void MainWindow::deleteVertex(Vertex *vertex)
+{
+    if (!vertex)
+        return;
+
+    const auto it = std::find_if(m_vertices.begin(), m_vertices.end(),
+                                 [vertex](const std::unique_ptr<Vertex> &candidate) {
+                                     return candidate.get() == vertex;
+                                 });
+
+    if (it != m_vertices.end()) {
+        m_vertices.erase(it);
+    }
+}
+
+QPointF MainWindow::nextVertexPosition() const
+{
+    const qreal spacing = 30.0;
+    const int index = static_cast<int>(m_vertices.size());
+    const qreal x = 50.0 + (index % 10) * spacing;
+    const qreal y = 50.0 + (index / 10) * spacing;
+    return QPointF(x, y);
+}
+
+void MainWindow::on_actionAdd_Vertex_triggered()
+{
+    createVertex(nextVertexPosition());
+}
+
+void MainWindow::on_actionDelete_Vertex_triggered()
+{
+    if (m_vertices.empty())
+        return;
+
+    Vertex *vertex = m_vertices.back().get();
+    deleteVertex(vertex);
+}
+
+void MainWindow::on_actionDelete_All_Vertices_triggered()
+{
+    m_vertices.clear();
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -2,6 +2,12 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
+#include <QPointF>
+#include <memory>
+#include <vector>
+
+class QGraphicsScene;
+class Vertex;
 
 QT_BEGIN_NAMESPACE
 namespace Ui {
@@ -17,7 +23,18 @@ public:
     MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
 
+private slots:
+    void on_actionAdd_Vertex_triggered();
+    void on_actionDelete_Vertex_triggered();
+    void on_actionDelete_All_Vertices_triggered();
+
 private:
+    Vertex *createVertex(const QPointF &position);
+    void deleteVertex(Vertex *vertex);
+    QPointF nextVertexPosition() const;
+
     Ui::MainWindow *ui;
+    QGraphicsScene *m_scene = nullptr;
+    std::vector<std::unique_ptr<Vertex>> m_vertices;
 };
 #endif // MAINWINDOW_H

--- a/polygons_on_white_canvas2.pro
+++ b/polygons_on_white_canvas2.pro
@@ -10,10 +10,12 @@ CONFIG += c++17
 
 SOURCES += \
     main.cpp \
-    mainwindow.cpp
+    mainwindow.cpp \
+    vertex.cpp
 
 HEADERS += \
-    mainwindow.h
+    mainwindow.h \
+    vertex.h
 
 FORMS += \
     mainwindow.ui

--- a/vertex.cpp
+++ b/vertex.cpp
@@ -1,0 +1,54 @@
+#include "vertex.h"
+
+#include <QGraphicsEllipseItem>
+#include <QGraphicsScene>
+#include <QPen>
+#include <QBrush>
+#include <QRectF>
+
+Vertex::Vertex(const QPointF &position, QGraphicsScene *scene, qreal radius)
+    : m_position(position)
+    , m_scene(scene)
+    , m_item(nullptr)
+    , m_radius(radius)
+{
+    if (m_scene) {
+        m_item = m_scene->addEllipse(0, 0, 0, 0, QPen(Qt::NoPen), QBrush(Qt::yellow));
+        if (m_item) {
+            m_item->setZValue(1.0);
+            updateGraphicsItem();
+        }
+    }
+}
+
+Vertex::~Vertex()
+{
+    if (m_scene && m_item) {
+        m_scene->removeItem(m_item);
+    }
+    delete m_item;
+    m_item = nullptr;
+}
+
+QPointF Vertex::position() const
+{
+    return m_position;
+}
+
+void Vertex::setPosition(const QPointF &position)
+{
+    m_position = position;
+    updateGraphicsItem();
+}
+
+void Vertex::updateGraphicsItem()
+{
+    if (!m_item)
+        return;
+
+    const QRectF rect(m_position.x() - m_radius,
+                      m_position.y() - m_radius,
+                      m_radius * 2,
+                      m_radius * 2);
+    m_item->setRect(rect);
+}

--- a/vertex.h
+++ b/vertex.h
@@ -1,0 +1,27 @@
+#ifndef VERTEX_H
+#define VERTEX_H
+
+#include <QPointF>
+
+class QGraphicsScene;
+class QGraphicsEllipseItem;
+
+class Vertex
+{
+public:
+    Vertex(const QPointF &position, QGraphicsScene *scene, qreal radius = 6.0);
+    ~Vertex();
+
+    QPointF position() const;
+    void setPosition(const QPointF &position);
+
+private:
+    void updateGraphicsItem();
+
+    QPointF m_position;
+    QGraphicsScene *m_scene;
+    QGraphicsEllipseItem *m_item;
+    qreal m_radius;
+};
+
+#endif // VERTEX_H


### PR DESCRIPTION
## Summary
- add a Vertex class that encapsulates position data and its graphics item in the scene
- initialize the main window with a graphics scene and utilities to create and delete vertices
- wire existing menu actions to add, remove, or clear vertices while keeping the project file in sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db8f59d0a883279dbcefb730cfbd50